### PR TITLE
Updates score threshold on k8s scan to fail if score is below 60

### DIFF
--- a/.github/workflows/mondoo_scan_k8s.yaml
+++ b/.github/workflows/mondoo_scan_k8s.yaml
@@ -19,3 +19,4 @@ jobs:
           scan_type: k8s
           path: dvwa-eks-deployment.yaml
           output_format: compact
+          score_threshold: 60

--- a/dvwa-eks-deployment.yaml
+++ b/dvwa-eks-deployment.yaml
@@ -19,5 +19,5 @@ spec:
           ports:
             - containerPort: 80
           securityContext:
-            privileged: true
+            privileged: false
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
We should be stricter about failing deployments that do not meet security standards. 

<img src="https://media4.giphy.com/media/26gsvAm8UPaczzXz2/giphy.gif"/>

Signed-off-by: Scott Ford <scott@scottford.io>