### PR TITLE
Updates security threshold for docker and k8s manifest scans

### DIFF
--- a/.github/workflows/mondoo_scan_docker.yaml
+++ b/.github/workflows/mondoo_scan_docker.yaml
@@ -19,3 +19,4 @@ jobs:
           scan_type: "docker_image_from_dockerfile"
           path: "Dockerfile"
           output_format: compact
+          score_threshold: 60

--- a/.github/workflows/mondoo_scan_k8s.yaml
+++ b/.github/workflows/mondoo_scan_k8s.yaml
@@ -19,3 +19,4 @@ jobs:
           scan_type: k8s
           path: dvwa-eks-deployment.yaml
           output_format: compact
+          score_threshold: 60


### PR DESCRIPTION
It is time we are more strict about failing builds that do not pass security standards. New threshold set to 60.

Signed-off-by: Scott Ford <scott@scottford.io>